### PR TITLE
fix: make ParseErrorBundle extend Error

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -263,7 +263,7 @@ export class LazyCustomError {
  * console.log(bundle.format("ansi")); // Formatted with colors
  * ```
  */
-export class ParseErrorBundle {
+export class ParseErrorBundle extends Error {
   /**
    * Creates a new ParseErrorBundle.
    * @param errors - Array of parsing errors
@@ -274,6 +274,8 @@ export class ParseErrorBundle {
   source: string
 
   constructor(errors: ParseError[], source: string) {
+    super()
+    this.name = "ParseErrorBundle"
     this.errors = errors
     this.source = source
   }
@@ -303,7 +305,7 @@ export class ParseErrorBundle {
    * Converts the primary error to a simple string representation.
    * @returns {string} A human-readable error message
    */
-  toString(): string {
+  override toString(): string {
     const err = this.primary
     switch (err.tag) {
       case "Expected":

--- a/tests/parse-error-bundle.test.ts
+++ b/tests/parse-error-bundle.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest"
+import { char } from "../src/combinators"
+import { ParseError, ParseErrorBundle, Span } from "../src/errors"
+
+describe("ParseErrorBundle", () => {
+  test("is an Error subclass with a name", () => {
+    const bundle = new ParseErrorBundle(
+      [
+        ParseError.expected({
+          span: Span({ offset: 0, line: 1, column: 1 }),
+          items: ["a"],
+          context: []
+        })
+      ],
+      "b"
+    )
+    expect(bundle instanceof Error).toBe(true)
+    expect(bundle instanceof ParseErrorBundle).toBe(true)
+    expect(bundle.name).toBe("ParseErrorBundle")
+  })
+
+  test("parseOrThrow throws a real Error with a stack", () => {
+    try {
+      char("a").parseOrThrow("b")
+      expect.unreachable("parseOrThrow should have thrown")
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toBeInstanceOf(ParseErrorBundle)
+      expect((error as ParseErrorBundle).name).toBe("ParseErrorBundle")
+      expect(typeof (error as Error).stack).toBe("string")
+      expect((error as Error).stack!.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
Bug: ParseErrorBundle was a plain class, so parseOrThrow threw a non-Error object: instanceof Error was false and there was no stack. Fix: extend Error, set name to ParseErrorBundle, keep existing toString() formatting. Tests: vitest 2 files / 24 passed including tests/parse-error-bundle.test.ts; tsc --noEmit passed. No version bump, no publish, no merge.