### PR TITLE
fix: preserve committed when .label() fails

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -533,7 +533,10 @@ export class Parser<T> {
 
       if (output.result._tag === "Left") {
         return ParserOutput(
-          state,
+          {
+            ...state,
+            committed: output.state.committed || state.committed
+          },
           Either.left(
             new ParseErrorBundle(
               [

--- a/tests/label-committed.test.ts
+++ b/tests/label-committed.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest"
+import { char, commit, or, parser, regex, string } from "../src"
+import { Either } from "../src/either"
+
+describe("label preserves committed", () => {
+  test("committed labeled alternative in or() does not fall through", () => {
+    // README letExpr.label pitfall: wrapping a committed rule in .label()
+    // used to rewind to the entry state and drop `committed`, so `or`
+    // would try the next branch and succeed with the wrong parse.
+    const name = regex(/[a-z]+/)
+    const number = regex(/-?\d+/).map(Number)
+
+    const letExpr = parser(function* () {
+      yield* string("let")
+      yield* char(" ")
+      yield* commit()
+      const n = yield* name
+      yield* char("=")
+      const value = yield* number
+      return { type: "let" as const, name: n, value }
+    }).label("let expression")
+
+    const variable = name.map(n => ({ type: "var" as const, name: n }))
+    const expr = or(letExpr, variable)
+
+    const { result } = expr.parse("let x 42")
+    expect(Either.isLeft(result)).toBe(true)
+  })
+
+  test("uncommitted labeled alternative still backtracks", () => {
+    const p = or(string("foo").label("foo"), string("bar"))
+    expect(p.parseOrThrow("bar")).toBe("bar")
+  })
+})


### PR DESCRIPTION
Bug: .label() rewound to the entry state and dropped committed, so a committed labeled alternative inside or() could fall through to the next branch (README letExpr.label pitfall). Fix: keep committed like .expect() so backtracking stays blocked after commit. Tests: vitest 2 files / 24 passed including tests/label-committed.test.ts; tsc --noEmit passed. No version bump, no publish, no merge.