### PR TITLE
fix: close Parser.gen iterator on failure

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -489,6 +489,7 @@ export class Parser<T> {
       while (!current.done) {
         const output = current.value.run(currentState)
         if (output.result._tag === "Left") {
+          iterator.return(undefined as T)
           return output as unknown as ParserOutput<T>
         }
         currentState = output.state

--- a/tests/parser-gen-cleanup.test.ts
+++ b/tests/parser-gen-cleanup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest"
+import { char, parser } from "../src"
+import { Either } from "../src/either"
+
+describe("Parser.gen closes the generator on failure", () => {
+  test("try/finally runs when an inner parser fails", () => {
+    let cleaned = false
+    const p = parser(function* () {
+      try {
+        yield* char("a")
+        yield* char("b")
+        return "ok"
+      } finally {
+        cleaned = true
+      }
+    })
+
+    const { result } = p.parse("ax")
+    expect(Either.isLeft(result)).toBe(true)
+    expect(cleaned).toBe(true)
+  })
+
+  test("try/finally still runs on success", () => {
+    let cleaned = false
+    const p = parser(function* () {
+      try {
+        const a = yield* char("a")
+        return a
+      } finally {
+        cleaned = true
+      }
+    })
+
+    expect(p.parseOrThrow("a")).toBe("a")
+    expect(cleaned).toBe(true)
+  })
+})


### PR DESCRIPTION
Bug: on Left, Parser.gen returned without iterator.return(), so try/finally in generator parsers never ran. Fix: call iterator.return() before returning the Left so cleanup still executes when an inner parser fails. Tests: vitest 2 files / 24 passed including tests/parser-gen-cleanup.test.ts; tsc --noEmit passed. No version bump, no publish, no merge.